### PR TITLE
Change MANUFACTURER_DIGITAL_CERT_MANUFACTURER_ATTRIBUTE_NAME to 'o' (Organization)

### DIFF
--- a/src/main/java/com/ispirit/digitalsky/configuration/ApplicationConfiguration.java
+++ b/src/main/java/com/ispirit/digitalsky/configuration/ApplicationConfiguration.java
@@ -79,7 +79,7 @@ public class ApplicationConfiguration {
     @Value("${DS_CERT_PRIVATE_KEY_PATH:classpath:key.pem}")
     private String digitalSkyPrivateKeyPath;
 
-    @Value("${MANUFACTURER_DIGITAL_CERT_MANUFACTURER_ATTRIBUTE_NAME:cn}")
+    @Value("${MANUFACTURER_DIGITAL_CERT_MANUFACTURER_ATTRIBUTE_NAME:o}")
     private String manufacturerDigitalCertManufacturerAttributeName;
 
     @Value("${MANUFACTURER_DIGITAL_CERT_VALIDATION_ENABLED:true}")


### PR DESCRIPTION
This is required because for Indian PKI DSCs, if a DSC is issued to an organization, the CN attribute is the name of the person to whom the DSC is issued while the O attribute is the name of the organization, which should be checked against Organization Name in Manufacturer Profile.
For example:
![Capture](https://user-images.githubusercontent.com/4189727/58641735-6006f300-8319-11e9-8882-dd171e075d19.JPG)

@CharanSahaj @bugobliterator @sidd-shetty @sidhantgoel 
